### PR TITLE
Pulsing Syntax Improvement

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -4,7 +4,7 @@ $( document ).ready(function() {
     
     var $this = $(this),
         audio = $this.siblings('audio')[0],
-        bpm = Number($this.siblings('audio').data('bpm'))
+        bpm = Number($this.siblings('audio').data('bpm')),
         pulse = (60/bpm)*1000;
     
     
@@ -26,11 +26,7 @@ $( document ).ready(function() {
     
     function pulsing() {
       
-      $this.addClass('pulse');
-      
-      setTimeout(function() {
-        $this.removeClass('pulse');  
-      }, pulse-100);
+      $this.removeClass('pulse').addClass('pulse');
       
     }
     


### PR DESCRIPTION
Instead of sheduling a removal of the class just before the pulse, you can simply write those two functions one after another. The addClass function will only be called after the removeClass function. 

I haven't tested it, so I might be wrong, but I think the time it takes for the removeClass function to remove the class is so tiny that you won't see any delays in the scaling of the player.

Great video by the way, keep on hacking!
